### PR TITLE
Restore logic to ignore heartbeats

### DIFF
--- a/agent/backend_etcd.go
+++ b/agent/backend_etcd.go
@@ -61,10 +61,7 @@ func (b *EtcdBackend) responseToUpdate(resp *etcd.Response, node *etcd.Node) *Se
 	}
 	serviceName := splitKey[3]
 	serviceAddr := splitKey[4]
-	//if "get" == resp.Action || ("set" == resp.Action && node.Value != node.PrevValue) {
-	// TODO: the above is broken right now. until then what happens if we don't ignore heartbeats?
-	// should be resolved soon: http://thread.gmane.org/gmane.comp.distributed.etcd/56
-	if "get" == resp.Action || "set" == resp.Action {
+	if "get" == resp.Action || "set" == resp.Action && (resp.PrevNode == nil || node.Value != resp.PrevNode.Value) {
 		// GET is because getCurrentState returns responses of Action GET.
 		// some SETs are heartbeats, so we ignore SETs where value didn't change.
 		var serviceAttrs map[string]string


### PR DESCRIPTION
@progrium etcd v0.3 added `Response.PrevNode`.
